### PR TITLE
Creation of new Barber on BurnData and pasive data

### DIFF
--- a/src/data/reserve.js
+++ b/src/data/reserve.js
@@ -145,9 +145,25 @@ export const barbers = [
         instagram: "https://www.instagram.com/ramiro_deleon1/",
         localName: "Art Experience",
         name: "Ramiro de León",
-        prestige: 4,
+        prestige: 5,
         urlProfileImage: "https://i.ibb.co/pP8Ct9g/Ramiro-Pereira.jpg",
         userId: 3,
         username: "Ramiro de León"
+    },
+    {
+        admin: true,
+        barber: true,
+        barberDescription: "",
+        barberId: 4,
+        email: "nicopineiro123@gmail.com",
+        facebook: "https://www.instagram.com/nicolasp.1899/",
+        instagram: "https://www.instagram.com/nicolasp.1899/",
+        localName: "Art Experience",
+        name: "Nicolas Piñeiro",
+        prestige: 5,
+        urlProfileImage: "https://i.ibb.co/h1L0TgG/Nicolas-Pi-eiro.jpg",
+        userId: 4,
+        username: "Nicolas Piñeiro"
     },   
+];
 ];

--- a/src/data/reserve.js
+++ b/src/data/reserve.js
@@ -166,4 +166,3 @@ export const barbers = [
         username: "Nicolas Piñeiro"
     },   
 ];
-];


### PR DESCRIPTION
### New Barber
 -  Nico Piñeiro

### COMMENT
No es como para pull request porque es un minicambio, pero la idea de este pr es dejarlo para discucion de mejores soluciones mas escalables que mockear la data, sabemos que hay un issue en el first load de los barberos pero hay que buscarle la vuelta para que se pueda setear mejor, mi idea ahora que vamos a meterle mano al dashboard.

### FEATURE
Es generar sea en Art, o sea en doGrowthB2C un panel donde se puedan añadir o dar de baja o editar estos barberos, de forma que si hay que hacer algo local se pueda hacer directamente en la web, esto lo que haria seria setear un json, con el burn data, agregando el nuevo barbero, y tambien yendo a la base de datos y crearlo directamente ahi, hasta encontrar la vuelta de la carga, lo cual creo que pasa por no tener un HOST seguro y confiable.. pero en fin. buena feature para solucionar todo esto. y tener un mejor control de los barberos.



### TEST
Confirmacion del deploy y prueba de que funciono:
Slides de Barberos: :heavy_check_mark: 
![image](https://user-images.githubusercontent.com/37275050/120942234-f0911e80-c6fd-11eb-867e-0b905f64d042.png)

Seleccion de barbero en reservacion: :heavy_check_mark: 
![image](https://user-images.githubusercontent.com/37275050/120942264-28986180-c6fe-11eb-8f68-90f17805c616.png)


Reservacion a modoo de prueba: :heavy_check_mark: 
![image](https://user-images.githubusercontent.com/37275050/120942212-cb041500-c6fd-11eb-9447-d6360cae5452.png)

