### PR TITLE
Adding meta to support the new backend url HTTP

### DIFF
--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -12,7 +12,7 @@ class MyDocument extends Document {
                 <Head>
                     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.min.css" />
                     <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick-theme.min.css" />
-
+                    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />
                 </Head>
                 <body>
                     <Main />


### PR DESCRIPTION
Añadi la nueva Meta para soportar las request HTTP por que nuestro nuevo backend no tiene Certificaciones SSL 
Queda por crear una pero de momento esta Meta nos salvara en production ya que este finde de semana estuvo caido.

![image](https://user-images.githubusercontent.com/37275050/123639261-63218580-d7f6-11eb-954c-21aaacd8cbe5.png)
